### PR TITLE
Address Issue #7 by making kleiDust.loadTemplate use fs.readFileSync.

### DIFF
--- a/lib/klei/dust.js
+++ b/lib/klei/dust.js
@@ -152,13 +152,13 @@ var kleiDust = function () {
 
         if (str) return callback(null, str);
 
-        fs.readFile(path, 'utf8', function(err, str){
-            if (err) return callback(err);
-
+        try {
+            str = fs.readFileSync(path, 'utf8');
             setCachedString(path, str);
-
             callback(null, str);
-        });
+        } catch(err) {
+            return callback(err);
+        }
     };
 
     var disableWhiteSpaceCompression = function () {

--- a/test/dust.js
+++ b/test/dust.js
@@ -2,6 +2,12 @@ var kleiDust = require('../lib/klei/dust'),
     should = require('should');
 
 describe("dust", function () {
+
+    beforeEach(function (done) {
+        kleiDust.setOptions({}); // reset options
+        done();
+    });
+
     it("should render templates", function (done) {
         var items = {
             items: [
@@ -13,6 +19,24 @@ describe("dust", function () {
         kleiDust.dust('templates/test', items, function (err, out) {
             should.not.exist(err);
             out.should.equal("<ul><li>Item 1</li><li>Item 2</li></ul>");
+            done();
+        });
+    });
+
+    // Confirm that we don't encounter an EMFILE error when loading the same template many times.
+    // See <https://github.com/klei-dev/dust/issues/7> for more detail.
+    it("[issue 7] should render templates that includes a partial many times", function (done) {
+        var count = 1000; // number of times to include the partial
+        var context = { items: [] };
+        for(var i=0; i < count; i++) {
+            var value = 'Item #'+i
+            context.items.push({item:value});
+        }
+        kleiDust.setOptions({root:__dirname,relativeToFile:false});
+        kleiDust.dust('templates/partial-parent', context, function (err, out) {
+            should.not.exist(err);
+            out.indexOf(context.items[0].item).should.be.above(-1);
+            out.indexOf(context.items[count-1].item).should.be.above(-1);
             done();
         });
     });

--- a/test/templates/partial-child.dust
+++ b/test/templates/partial-child.dust
@@ -1,0 +1,5 @@
+{!
+   This is template is a "partial", included in `partial-parent.dust`.
+   This template is used by tests in `test/dust.js`.
+!}
+The item is {item}.

--- a/test/templates/partial-parent.dust
+++ b/test/templates/partial-parent.dust
@@ -1,0 +1,9 @@
+{!
+   This template references a "partial", defined in `partial-child.dust`.
+   This template is used by tests in `test/dust.js`.
+!}
+<ul>
+{#items}
+    <li>{>"templates/partial-child"/}</li>
+{/items}
+</ul>


### PR DESCRIPTION
This patch addresses issue #7 as discussed at [github.com/klei-dev/dust/issues/7](https://github.com/klei-dev/dust/issues/7).

The `kleiDust.loadTemplate` method is modified to load templates synchronously in order to allow templates a chance to be added to the cache, even when loaded many times in quick succession.

A test case is included (in `test/dust.js`).  Two new files were added to `test/templates` in support of this test. 
