### PR TITLE
Fix for init of 'dustjs-helpers'

### DIFF
--- a/lib/klei/dust.js
+++ b/lib/klei/dust.js
@@ -1,6 +1,7 @@
-var dust = require('dustjs-linkedin'),
-    fs = require('fs');
-    pathlib = require('path');
+var dust = require('dustjs-linkedin')
+  , helpers = require('dustjs-helpers')
+  , fs = require('fs')
+  , pathlib = require('path');
 
 var kleiDust = function () {
     var self = this,
@@ -65,8 +66,10 @@ var kleiDust = function () {
         return dust;
     };
 
-    this.setHelpers = function (helpers) {
-        dust.helpers = helpers;
+    this.setHelpers = function () {
+        if (typeof dust.helpers === "undefined" || dust.helpers === null) {
+            dust.helpers = {};
+        }
         return dust;
     };
 
@@ -192,7 +195,7 @@ var kleiDust = function () {
     var whiteSpaceKeeper = function(ctx, node) { return node; };
 
     var loadHelpers = function () {
-        self.setHelpers(require('dustjs-helpers').helpers);
+        self.setHelpers();
     };
 
     var initializeDust = function (locals) {


### PR DESCRIPTION
It would appear that the latest version of dustjs-helpers requires a different syntax for instantiation and usage. Small modification to setHelpers function, so the useHelpers option now works as expected.
