### PR TITLE
adding option "baseContext"

### DIFF
--- a/lib/klei/dust.js
+++ b/lib/klei/dust.js
@@ -33,6 +33,9 @@ var kleiDust = function () {
     this.setOptions = function (options) {
         initializeSettings();
 
+        if (typeof options.baseContext !== 'undefined')
+            settings.baseContext = dust.makeBase(options.baseContext);
+
         if (typeof options.root !== 'undefined')
             settings.root = options.root;
 
@@ -101,6 +104,14 @@ var kleiDust = function () {
             return true;
 
         return false;
+    };
+
+    this.parseContext = function (locals) {
+        if (settings && settings.baseContext) {
+            return settings.baseContext.push(locals);
+        }
+
+        return locals;
     };
 
     this._doResolveRelativePath = function (locals) {
@@ -223,7 +234,7 @@ var kleiDust = function () {
 
         var template = getCachedTemplate(path);
 
-        if (template) return template(locals, callback);
+        if (template) return template(self.parseContext(locals), callback);
 
         loadTemplate(path, locals, function(err, str) {
             if (err) return callback(err);
@@ -240,7 +251,7 @@ var kleiDust = function () {
 
                 setCachedTemplate(path, template);
 
-                template(locals, callback);
+                template(self.parseContext(locals), callback);
             } catch (e) {
                 callback(e);
             }


### PR DESCRIPTION
This pull request intends to provide an option to set a base context using dust's **makeBase** method.

Setting the option:

``` javascript
var kleiDust = require('klei-dust');

kleiDust.setOptions({
    baseContext: {
        config: {
            cdnUrl: 'https://mycdn.com'
        }
    }
});
```

Using it:

``` html
<script src="{config.cdnUrl}/js/all.js"></script>
```

This way we don't need to set these config options every time, neither use `app.set` that pushes the objects to the **settings** property.
