### PR TITLE
append a space on every line before compile

### DIFF
--- a/lib/klei/dust.js
+++ b/lib/klei/dust.js
@@ -184,6 +184,7 @@ var kleiDust = function () {
 
         try {
             str = fs.readFileSync(path, 'utf8');
+            str = str.replace(/(\r\n|\n|\r)/gm," \n");
             setCachedString(path, str);
             callback(null, str);
         } catch(err) {


### PR DESCRIPTION
The dust compiler removes leading spaces on every line before joining them together.  So, if a trailing space is missing, two lines may join together without any space between time, which is often unexpected by the template writer.
